### PR TITLE
fix: build script to have the ui working again

### DIFF
--- a/build-script.sh
+++ b/build-script.sh
@@ -1,7 +1,6 @@
 #! /bin/bash
 
 rm -rf dxc_build_*
-rm -rf build
 
 set -e
 

--- a/build-script.sh
+++ b/build-script.sh
@@ -15,3 +15,4 @@ pushd ui
 npm i
 npm run build
 popd
+mv ui/build ${BUILD_DIR}/build

--- a/build-script.sh
+++ b/build-script.sh
@@ -5,13 +5,13 @@ rm -rf build
 
 set -e
 
-mkdir "dxc_build_$(date +%Y%m%d)"
-go build -o "dxc_build_$(date +%Y%m%d)"/dxc
-touch "dxc_build_$(date +%Y%m%d)"/dxc.db
-cp .env "dxc_build_$(date +%Y%m%d)"/.env
-cd ui
+BUILD_DIR=dxc_build_$(date +%Y%m%d)
+
+mkdir ${BUILD_DIR}
+go build -o ${BUILD_DIR}/dxc
+touch ${BUILD_DIR}/dxc.db
+cp .env ${BUILD_DIR}/.env
+pushd ui
 npm i
 npm run build
-cd ..
-cp -r build/ "dxc_build_$(date +%Y%m%d)"/build
-mv build ui/build
+popd

--- a/ui/package.json
+++ b/ui/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build && mv build ../",
+    "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
Removed `mv build ui/build` as it removed the build folder that is used to display the ui.