### PR TITLE
feat: docker builds for mycsn

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,6 +1,9 @@
 # Infura project id
 INFURA_ID=8376423gqweifb34287rg17gf
 
-# DXC IP
+# DXC IP/URL for access from outside
 DXC_HOST=localhost
 #DXC_HOST=xx:xx:xx:xx
+
+# DXC IP for access from ui to server
+DXC_SERVER_HOST=localhost

--- a/.env-example
+++ b/.env-example
@@ -2,5 +2,5 @@
 INFURA_ID=8376423gqweifb34287rg17gf
 
 # DXC IP
-REACT_APP_DXC_HOST=localhost
-#REACT_APP_DXC_HOST=xx:xx:xx:xx
+DXC_HOST=localhost
+#DXC_HOST=xx:xx:xx:xx

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,4 @@
-FROM mhart/alpine-node:12 AS ui
-WORKDIR /
-COPY /ui .
-ARG REACT_APP_DXC_HOST
-ENV REACT_APP_DXC_HOST $REACT_APP_DXC_HOST
-RUN npm install --silent
-RUN npm run build --silent
-
-FROM alpine:edge as api
+FROM alpine:edge
 RUN apk update
 RUN apk upgrade
 RUN apk add --update go=1.13.10-r0 gcc=9.3.0-r2 g++=9.3.0-r2 linux-headers
@@ -14,13 +6,7 @@ WORKDIR /
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
+RUN touch dxc.db
 # CGO_ENABLED=1 is required for sqlite to work
 RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -o main .
-
-FROM alpine:edge
-WORKDIR /
-RUN mkdir build
-RUN touch dxc.db
-COPY --from=ui build ./build
-COPY --from=api main .
 CMD ["./main"]

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ Navigate to localhost:8080
 INFURA_ID=111111111111111111
 
 # DXC IP
-REACT_APP_DXC_HOST=localhost
-#REACT_APP_DXC_HOST=xx:xx:xx:xx
+DXC_HOST=localhost
+#DXC_HOST=xx:xx:xx:xx
 ```
 
 ### Dependencies

--- a/datasources/status-ticker.go
+++ b/datasources/status-ticker.go
@@ -104,7 +104,7 @@ func SendStatus() {
 	bodyRequest := &DXCObject{
 		Challenge: challenge.Challenge,
 		Address:   userAuth.Address,
-		Host:      os.Getenv("REACT_APP_DXC_HOST"),
+		Host:      os.Getenv("DXC_HOST"),
 		Port:      "8080",
 	}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,12 +2,14 @@ version: "3"
 
 services:
   dxc-server:
-    image: dxc-server
+    image: databrokerdao/dxc-server:alpha-latest
     ports:
       - "8080:8080"
     env_file:
       - .env
   dxc-ui:
-    image: dxc-ui
+    image: databrokerdao/dxc-ui:alpha-latest
     ports:
       - "1337:80"
+    env_file:
+      - .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,13 @@
 version: "3"
 
 services:
-  client:
-    build:
-      context: .
-      dockerfile: Dockerfile
-      args:
-      - REACT_APP_DXC_HOST=${REACT_APP_DXC_HOST}
-    volumes:
-      - ${LOCAL_FILES_DIR}:/var/files
+  dxc-server:
+    image: dxc-server
     ports:
       - "8080:8080"
     env_file:
       - .env
+  dxc-ui:
+    image: dxc-ui
+    ports:
+      - "1337:80"

--- a/server.go
+++ b/server.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"log"
+	"os"
 	"sync"
 
 	"github.com/fatih/color"
@@ -105,6 +107,11 @@ func main() {
 	err := godotenv.Load()
 	if err != nil {
 		e.Logger.Info("No env file loaded. It's ok if you are running with docker and if you passed the .enf file that way.")
+	}
+
+	dxcHost := os.Getenv("DXC_HOST")
+	if dxcHost == "" {
+		log.Fatalf("DXC_HOST env variable is not set!")
 	}
 
 	/////////////////

--- a/server.go
+++ b/server.go
@@ -104,7 +104,7 @@ func main() {
 	// Loading env file
 	err := godotenv.Load()
 	if err != nil {
-		e.Logger.Error("No env file loaded...")
+		e.Logger.Info("No env file loaded. It's ok if you are running with docker and if you passed the .enf file that way.")
 	}
 
 	/////////////////

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,0 +1,16 @@
+# build environment
+FROM node:13.12.0-alpine as build
+WORKDIR /app
+ENV PATH /app/node_modules/.bin:$PATH
+COPY package.json ./
+COPY package-lock.json ./
+RUN npm ci --silent
+RUN npm install react-scripts@3.4.1 -g --silent
+COPY . ./
+RUN npm run build
+
+# production environment
+FROM nginx:stable-alpine
+COPY --from=build /app/build /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -12,5 +12,7 @@ RUN npm run build
 # production environment
 FROM nginx:stable-alpine
 COPY --from=build /app/build /usr/share/nginx/html
+COPY env2js.sh ./
+RUN ["chmod", "+x", "./env2js.sh"]
 EXPOSE 80
-CMD ["nginx", "-g", "daemon off;"]
+CMD sh -c './env2js.sh > /usr/share/nginx/html/config.js && nginx -g "daemon off;"'

--- a/ui/env2js.sh
+++ b/ui/env2js.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# used to set variable from docker-compose env variables
+
+if [ ! -z ${DXC_SERVER_HOST} ]; then
+ cat <<END
+ window.DXC_SERVER_HOST="${DXC_SERVER_HOST}";
+END
+fi

--- a/ui/public/config.js
+++ b/ui/public/config.js
@@ -1,0 +1,1 @@
+window.DXC_SERVER_HOST = undefined

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -17,6 +17,8 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
 
+    <script src="config.js"></script>
+
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -13,10 +13,14 @@ import {
   Tab,
 } from "@material-ui/core";
 import CssBaseline from "@material-ui/core/CssBaseline";
-import { useWindowSize } from "./WindowSizeHook";
+
+declare global {
+  interface Window {
+    DXC_SERVER_HOST: string
+  }
+}
 
 function App() {
-  const [width] = useWindowSize();
   const [tabValue, setTabValue] = React.useState<string>("pane-DS");
 
   const handleChangedTab = (event: any, newValue: string) => {
@@ -41,10 +45,9 @@ function App() {
         container
         style={{ marginTop: "2%" }}
         spacing={2}
-        direction={width < 1286 ? "column" : "row"}
       >
         {tabValue === "pane-DS" ?
-          <Grid item xs={width < 1286 ? 12 : 6}>
+          <Grid item xs={12}>
             <Grid style={{ marginBottom: "50px", }} item xs={12}>
               <DatasourceForm />
             </Grid>
@@ -55,7 +58,7 @@ function App() {
             </Grid>
           </Grid> : null}
         {tabValue === "pane-AUTH" ?
-          <Grid item xs={width < 1286 ? 12 : 6}>
+          <Grid item xs={12}>
             <Typography variant="subtitle1">Authentication</Typography>
             <Divider />
             <Grid item xs={12}>

--- a/ui/src/fetchers.ts
+++ b/ui/src/fetchers.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 
 const LOCAL_PORT = 8080;
-export const LOCAL_HOST = `http://127.0.0.1:${LOCAL_PORT}`;
+export const LOCAL_HOST = `${window.DXC_SERVER_HOST || "http://localhost"}:${LOCAL_PORT}`;
 
 export const fetcher = (ROUTE: string) => axios(`${LOCAL_HOST}${ROUTE}`);

--- a/ui/src/fetchers.ts
+++ b/ui/src/fetchers.ts
@@ -1,8 +1,6 @@
 import axios from "axios";
 
 const LOCAL_PORT = 8080;
-// export const LOCAL_HOST = `http://${process.env.REACT_APP_DXC_HOST || "localhost"}:${LOCAL_PORT}`;
-
 export const LOCAL_HOST = `http://127.0.0.1:${LOCAL_PORT}`;
 
 export const fetcher = (ROUTE: string) => axios(`${LOCAL_HOST}${ROUTE}`);


### PR DESCRIPTION
Reviewed the docker builds and docker-compose to allow the use of the dxc server without the ui.

As localhost does not work inside 2 different containers for communicating from the ui to the api, used this way to use server ip env variable in react app: https://medium.com/@vietgoeswest/passing-env-variables-from-the-server-to-your-create-react-app-c87578a45358