### PR TITLE
feat smaller docker image without the sources

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,13 +4,13 @@ services:
   dxc-server:
     image: databrokerdao/dxc-server:alpha-latest
     volumes:
-      - ./db-data:/db-data
+      - ./db-data:/go/db-data
     ports:
       - "8080:8080"
     env_file:
       - .env
   dxc-ui:
-    image: databrokerdao/dxc-ui:latest
+    image: databrokerdao/dxc-ui:alpha-latest
     ports:
       - "1337:80"
     env_file:


### PR DESCRIPTION
When I split the docker images a while back (for MyCSN), I left all the sources in the server docker image. This should make it cleaner.